### PR TITLE
Moddable support, singleton, ttypescript transformer and constructor error handling improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Features
 
-- Added support for the embedded JavaScript platform [Moddable](https://github.com/Moddable-OpenSource/moddable), including a `manifest.json` file (similar in concept to `package.json`).
+- Added support for the embedded JavaScript platform [Moddable](https://github.com/Moddable-OpenSource/moddable), including a `manifest.json` file (similar in concept to `package.json`) and preloading (reducing memory consumption with storing preloaded slots/chunks in flash).
 - Added a `transformer.js` file to make it easier to use `ttypescript`
 - Added a new API for a accessing a singleton instance of `DIContainer`.  Useful for sharing a container across independent libraries so prior registrations can be consumed by shared libraries.  `DIContainer.singleton` accesses the singleton of `DIContainer`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,3 @@
-# 2.1.1 (2022-05-26)
-
-### Bug fixes
-
-- Improved error reporting on class instantiations that throw errors by throwing the first error received rather than the failsafe attempt that attempts constructing without using `new`.
-
-### Features
-
-- Added support for the embedded JavaScript platform [Moddable](https://github.com/Moddable-OpenSource/moddable), including a `manifest.json` file (similar in concept to `package.json`) and preloading (reducing memory consumption with storing preloaded slots/chunks in flash).
-- Added a `transformer.js` file to make it easier to use `ttypescript`
-- Added a new API for a accessing a singleton instance of `DIContainer`.  Useful for sharing a container across independent libraries so prior registrations can be consumed by shared libraries.  `DIContainer.singleton` accesses the singleton of `DIContainer`.
-
 # 2.1.0 (2022-04-07)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 2.1.1 (2022-05-26)
+
+### Bug fixes
+
+- Improved error reporting on class instantiations that throw errors by throwing the first error received rather than the failsafe attempt that attempts constructing without using `new`.
+
+### Features
+
+- Added support for the embedded JavaScript platform [Moddable](https://github.com/Moddable-OpenSource/moddable), including a `manifest.json` file (similar in concept to `package.json`).
+- Added a `transformer.js` file to make it easier to use `ttypescript`
+- Added a new API for a accessing a singleton instance of `DIContainer`.  Useful for sharing a container across independent libraries so prior registrations can be consumed by shared libraries.  `DIContainer.singleton` accesses the singleton of `DIContainer`.
+
 # 2.1.0 (2022-04-07)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ container.registerSingleton<IAppConfig>(() => myAppConfig);
 container.registerSingleton<MyAwesomeService>();
 ```
 
+You can also use the `DIContainer.singleton` getter to use a shared, global instance of the container, which is useful when sharing registrations across shared libraries:
+
+```ts
+DIContainer.singleton.registerTransient<IMyService, MyService>();
+```
+
+
 ### Retrieving instances of services
 
 #### Injecting instances of services into classes
@@ -203,6 +210,10 @@ It may look like it, but I assure you it is quite simple. [Read this answer for 
 #### Is it possible to have multiple, scoped containers?
 
 Sure. You can instantiate as many as you want to, as long as you make sure the [Custom Transformer for DI](https://github.com/wessberg/di-compiler) get's to see the files that contain them.
+
+#### Can registered interfaces be shared across libraries?
+
+Yes, and you will need to share the `DIContainer` across those libraries.  A singleton of `DIContainer` is available to assist with sharing by using `DIContainer.singleton`.
 
 <!-- SHADOW_SECTION_LICENSE_START -->
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+	"modules": {
+		"@wessberg/di": ["dist/esm/index"],
+		"@wessberg/di.d": ["dist/esm/index.d"]
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,5 +2,8 @@
 	"modules": {
 		"@wessberg/di": ["dist/esm/index"],
 		"@wessberg/di.d": ["dist/esm/index.d"]
-	}
+	},
+	"preload": [
+		"@wessberg/di"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wessberg/di",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "A compile-time powered Dependency-Injection container for Typescript that holds services and can produce instances of them as required.",
   "scripts": {
     "generate:sandhog": "sandhog all --yes",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wessberg/di",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A compile-time powered Dependency-Injection container for Typescript that holds services and can produce instances of them as required.",
   "scripts": {
     "generate:sandhog": "sandhog all --yes",
@@ -14,6 +14,7 @@
     "prewatch": "pnpm run clean",
     "watch": "pnpm run prewatch && pnpm run rollup -- --watch",
     "rollup": "rollup -c rollup.config.js",
+    "transformer": "copyfiles -f src/transformer/transformer.js dist/transformer",
     "preversion": "pnpm run lint && pnpm run build",
     "version": "pnpm run preversion && pnpm run generate:all && git add .",
     "release": "np --no-cleanup --no-yarn --no-tests",
@@ -37,7 +38,7 @@
     "@typescript-eslint/parser": "^5.26.0",
     "@wessberg/ts-config": "^2.0.2",
     "rollup-plugin-ts": "^2.0.7",
-    "typescript": "4.6.4",
+    "typescript": "~4.6.4",
     "tslib": "^2.4.0",
     "npm-check-updates": "^13.0.3",
     "sandhog": "^1.0.43",
@@ -52,7 +53,8 @@
     "prettier": "^2.6.2",
     "pretty-quick": "^3.1.3",
     "rimraf": "^3.0.2",
-    "rollup": "^2.74.1"
+    "rollup": "^2.74.1",
+    "copyfiles": "^2.4.1"
   },
   "dependencies": {},
   "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit && eslint \"src/**/*.ts\" --color",
     "prettier": "prettier --write \"{src,test,documentation}/**/*.{js,ts,json,html,xml,css,md}\"",
     "prebuild": "pnpm run clean",
-    "build": "pnpm run prebuild && pnpm run rollup",
+    "build": "pnpm run prebuild && pnpm run rollup && pnpm run transformer",
     "prewatch": "pnpm run clean",
     "watch": "pnpm run prewatch && pnpm run rollup -- --watch",
     "rollup": "rollup -c rollup.config.js",

--- a/src/di-container/di-container.ts
+++ b/src/di-container/di-container.ts
@@ -366,7 +366,7 @@ export class DIContainer implements IDIContainer {
       );
     }
 
-    return this.diContainerMaps;
+    return this.writableDiContainerMaps;
   }
 }
 

--- a/src/di-container/di-container.ts
+++ b/src/di-container/di-container.ts
@@ -22,6 +22,11 @@ import { ImplementationInstance } from "../implementation/implementation";
  */
 export class DIContainer implements IDIContainer {
   /**
+   * Singleton instance of the container, for global sharing of the container.  
+   */
+   private static diContainer?: DIContainer;
+
+   /**
    * A map between interface names and the services that should be dependency injected
    */
   private readonly constructorArguments: Map<string, ConstructorArgument[]> =
@@ -144,6 +149,25 @@ export class DIContainer implements IDIContainer {
       );
     }
     return this.serviceRegistry.has(options.identifier);
+  }
+
+  /**
+   * Provides a global shared instance of a container (singleton).  This is
+   * especially useful when creating libraries (such as in a monorepo) where
+   * the library's imported file defines the dependencies that need to be
+   * injected for the library to operate without exposing the full set of
+   * injections necessary for each library.
+   * 
+   * Example:
+   * ```ts
+   * DIContainer.singleton.register<MyInterface, MyImplementation>();
+   * ```
+   *
+   * @returns Singleton container.
+   */
+   static get singleton(): DIContainer {
+    if (!DIContainer.diContainer) DIContainer.diContainer = new DIContainer();
+    return DIContainer.diContainer;
   }
 
   /**
@@ -314,9 +338,14 @@ export class DIContainer implements IDIContainer {
         }
         const constructable = registrationRecord.implementation;
         // Try without 'new' and call the implementation as a function.
-        instance = (constructable as unknown as CallableFunction)(
-          ...instanceArgs
-        );
+        try {
+          instance = (constructable as unknown as CallableFunction)(
+            ...instanceArgs
+          );
+        } catch {
+          // throw the original error, as it is likely more descriptive than this alternative attempt
+          throw ex;
+        }
       }
     }
 

--- a/src/di-container/i-di-container.ts
+++ b/src/di-container/i-di-container.ts
@@ -6,6 +6,8 @@ import {
 import { IGetOptions } from "../get-options/i-get-options";
 import { IHasOptions } from "../has-options/i-has-options";
 import { ImplementationInstance } from "../implementation/implementation";
+import { ConstructorArgument } from '../constructor-arguments/constructor-argument';
+import { RegistrationRecord } from '../registration-record/i-registration-record';
 
 export interface IDIContainer {
   registerSingleton<T, U extends T = T>(
@@ -35,4 +37,29 @@ export interface IDIContainer {
   get<T>(options?: IGetOptions): T;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   has<T>(options?: IHasOptions): boolean;
+}
+
+
+/**
+  * Contains all maps in a object, so that Moddable can "preload" the object into flash memory.  See
+  * https://github.com/Moddable-OpenSource/moddable/blob/83dadd3def6d2e7e75fc003a5ab409aa81275dd8/documentation/xs/preload.md
+  * for information on Moddable preloading, but the basic concept is code that the startup code is
+  * executed during the linker so that the resulting slots (variables) can be placed into flash ROM to
+  * reduce the memory footprint.  By moving these maps into an object, Moddable will freeze the object
+  * but allow the members (the maps) to be writable at runtime.
+  */
+export interface IDIContainerMaps {
+  /**
+   * A map between interface names and the services that should be dependency injected
+   */
+  constructorArguments: Map<string, ConstructorArgument[]>;
+  /**
+   * A Map between identifying names for services and their IRegistrationRecords.
+   */
+  serviceRegistry: Map<string, RegistrationRecord<unknown>>;
+
+  /**
+   * A map between identifying names for services and concrete instances of their implementation.
+   */
+  instances: Map<string, unknown>;
 }

--- a/src/transformer/transformer.js
+++ b/src/transformer/transformer.js
@@ -1,0 +1,3 @@
+const { di } = require("@wessberg/di-compiler");
+const transformer = (program) => di({ program });
+module.exports = transformer;


### PR DESCRIPTION
This pull contains:

* Support for the Moddable JavaScript platform. This is the biggest change, as Moddable has a cool but unusual feature where it can run the code at compile/link time and save the slots/chunks into flash memory, greatly reducing the footprint. When used, it requires you be more aware of certain data types as they will become read-only - in DI's case this was for three Map variables. You will see some trickery to handle those getting filled with DI registrations during preload, and then switching at runtime to a writable map for any runtime registrations. See the comments and the change log.

* Support for an optional singleton DIContainer.singleton to make sharing of a common container across libraries easier.

* Added the ttypescript transformer file, and included it into the dist directory making it easier to consume ttypescript

* Updated the constructor error handling per #5 - now reports the first error encountered, rather than the last-ditch attempt error which is usually misleading.
