### PR TITLE
Improve quality of get instantiation exceptions

### DIFF
--- a/src/di-container/di-container.ts
+++ b/src/di-container/di-container.ts
@@ -314,9 +314,14 @@ export class DIContainer implements IDIContainer {
         }
         const constructable = registrationRecord.implementation;
         // Try without 'new' and call the implementation as a function.
-        instance = (constructable as unknown as CallableFunction)(
-          ...instanceArgs
-        );
+        try {
+          instance = (constructable as unknown as CallableFunction)(
+            ...instanceArgs
+          );
+        } catch {
+          // throw the original error, as it is likely more descriptive than this alternative attempt
+          throw ex;
+        }
       }
     }
 

--- a/src/di-container/di-container.ts
+++ b/src/di-container/di-container.ts
@@ -312,16 +312,14 @@ export class DIContainer implements IDIContainer {
             `${this.constructor.name} could not construct a new service of kind: ${identifier}. Reason: No implementation was given!`
           );
         }
-        const constructable = registrationRecord.implementation;
-        // Try without 'new' and call the implementation as a function.
-        try {
-          instance = (constructable as unknown as CallableFunction)(
-            ...instanceArgs
-          );
-        } catch {
-          // throw the original error, as it is likely more descriptive than this alternative attempt
+        if (!(ex instanceof TypeError)) {
           throw ex;
         }
+        const constructable = registrationRecord.implementation;
+        // Try without 'new' and call the implementation as a function.
+        instance = (constructable as unknown as CallableFunction)(
+          ...instanceArgs
+        );
       }
     }
 


### PR DESCRIPTION
When `DIContainer.constructInstance` fails to instantiate using `new`, it tries to call the implementation as a function.  This causes exceptions in constructors to get lost, as the original exception is replaced with the thrown exception from the direct implementation call (which would never work if it was a valid constructor but had an internal error).  

I addressed this issue by adding a check if the error is not a `TypeError` when `new` is used (as that would be the error when the attempted instantiation was not constructable) which allows the constructor exception to be thrown.  If instead we get a `TypeError` (likely because the implementation was not constructable) we proceed to instantiate using the implementation function directly and let that error be handled naturally.  The small gap here is if the original constructor throws a TypeError, we would not know it was a constructor and process with the invalid error, but I found we can't check the message itself to know why as the message is different depending on the platform (specifically, Moddable vs. Node).  I felt this small window was much better than the wide window (always) that exists now.

Addresses #5.