### PR TITLE
Support for Moddable XS via injectable interface to access maps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,6 @@
+{
+	"modules": {
+		"@wessberg/di": ["dist/index"]
+	},
+	"preload": ["@wessberg/di"]
+}

--- a/src/di-container.ts
+++ b/src/di-container.ts
@@ -2,20 +2,20 @@ import {CONSTRUCTOR_ARGUMENTS_SYMBOL, DI_COMPILER_ERROR_HINT} from "./constant.j
 import {InstantiationError} from "./error.js";
 
 import type {
-	ConstructInstanceOptions,
-	ConstructorArgument,
-	DIContainerOptions,
-	GetOptions,
-	HasOptions,
 	IDIContainer,
-	IDIContainerMaps,
+	RegistrationRecord,
 	ImplementationInstance,
-	Parent,
+	RegistrationKind,
+	ConstructorArgument,
+	RegisterOptionsWithoutImplementation,
 	RegisterOptions,
 	RegisterOptionsWithImplementation,
-	RegisterOptionsWithoutImplementation,
-	RegistrationKind,
-	RegistrationRecord
+	GetOptions,
+	HasOptions,
+	ConstructInstanceOptions,
+	DIContainerOptions,
+	IDIContainerMaps,
+	Parent
 } from "./type.js";
 import {isClass, isCustomConstructableService} from "./util.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export type {IDIContainer} from "./type.js";
+export type {IDIContainer, ConstructorArgument, IContainerMap, RegistrationRecord} from "./type.js";
 export {DIContainer} from "./di-container.js";
 export {CONSTRUCTOR_ARGUMENTS_SYMBOL, CONSTRUCTOR_ARGUMENTS_SYMBOL_IDENTIFIER} from "./constant.js";

--- a/src/type.ts
+++ b/src/type.ts
@@ -64,3 +64,29 @@ export interface IDIContainer {
 	// @ts-expect-error The 'T' type parameter is required for compile-time reflection, even though it is not part of the signature.
 	has<T>(options?: HasOptions): boolean;
 }
+
+export interface IContainerMap<K extends string, V> {
+	get(key: K): V | undefined;
+	set(key: K, value: V): void;
+}
+
+export interface IDIContainerMaps {
+	/**
+	 * A map between interface names and the services that should be dependency injected
+	 */
+	constructorArguments: IContainerMap<string, ConstructorArgument[]>;
+
+	/**
+	 * A Map between identifying names for services and their IRegistrationRecords.
+	 */
+	serviceRegistry: IContainerMap<string, RegistrationRecord<unknown>>;
+
+	/**
+	 * A map between identifying names for services and concrete instances of their implementation.
+	 */
+	instances: IContainerMap<string, unknown>;
+}
+
+export interface DIContainerOptions {
+	customContainerMaps?: IDIContainerMaps;
+}


### PR DESCRIPTION
In PR #12 (now closed), the suggestion was to expose a hook from DI to abstract access to the maps and remove Moddable-specific code from the implementation.  This new PR takes that approach using the container constructor to optionally inject a storage implementation.

1) A new `options?` property on the container constructor, containing an optional injectable implementation for the container maps (`customContainerMaps: IDIContainerMaps`).  When specified, it is used for container map access else it defaults to simple Maps as before.
2) Minor adjustments to support the new hook by changing all map access to use the `this.#containerMaps` object (which then has the three maps).
3) A minor change when a singleton is registered more than once.  Before this change, registering a new implementation for a prior-registered (and allocated) identifier would not allocate a new instance matching the new registration implementation.  This change clears the prior instance upon re-registration to ensure a new allocation of the updated implementation is used.  I can see debating the need for this feature, or the behavior (losing a prior allocated singleton vs. not using the new implementation), but I imagine few people encounter this edge case.  For my use case, it's critical because my modules self-register at load time, and then my unit tests may change the registration (for mocking), so I need the most current singleton registration to be the active one.  If there is a need for the prior implementation, we now have the extensible `options` object on the constructor and can easily make the behavior selectable.
4) Included a `manifest.json` file as required Moddable to import and build.

This is running well (with a custom Moddable map-hook and default hook for Node) across our code base, and passing all our tests.  

Let me know if this approach is closer to what you were thinking or if we need to adjust further.
